### PR TITLE
Gravity fix

### DIFF
--- a/Assets/Animations/SquareWinSpriteSheet_0.controller
+++ b/Assets/Animations/SquareWinSpriteSheet_0.controller
@@ -1,28 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1107 &-461317575355518676
-AnimatorStateMachine:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Base Layer
-  m_ChildStates:
-  - serializedVersion: 1
-    m_State: {fileID: 4518053436165338328}
-    m_Position: {x: 400, y: 120, z: 0}
-  m_ChildStateMachines: []
-  m_AnyStateTransitions: []
-  m_EntryTransitions: []
-  m_StateMachineTransitions: {}
-  m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
-  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 4518053436165338328}
---- !u!1101 &-216396112368241810
+--- !u!1101 &-1896111652036373512
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -44,6 +22,28 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1107 &-461317575355518676
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 4518053436165338328}
+    m_Position: {x: 380, y: 110, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 4518053436165338328}
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -77,7 +77,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -216396112368241810}
+  - {fileID: -1896111652036373512}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Code/Scripts/Manager/LevelManager.cs
+++ b/Assets/Code/Scripts/Manager/LevelManager.cs
@@ -186,7 +186,6 @@ public class LevelManager : MonoBehaviour, ILevelManager
     //SubLevel ID is relative to current level
     public bool InjectSubLevel(int subLevelID, Vector3 position)
     {
-        Physics2D.gravity = new Vector2(0f, -9.8f);
         if (currentSubLevelID == -1 && currentLevelID != -1)
         {
             // if the level is complete, don't reload it

--- a/Assets/Code/Scripts/Obj/Level/WinCondition/BoundaryWin.cs
+++ b/Assets/Code/Scripts/Obj/Level/WinCondition/BoundaryWin.cs
@@ -44,7 +44,7 @@ public class BoundaryWin : MonoBehaviour
         Animator anim1 = winEffect1.GetComponent<Animator>();
         Animator anim2 = winEffect2.GetComponent<Animator>();
 
-        anim1.Play("Base Layer." + _shape + "Win", 5);
-        anim2.Play("Base Layer." + _shape + "Win", 5);
+        anim1.Play("Base Layer." + _shape + "Win");
+        anim2.Play("Base Layer." + _shape + "Win");
     }
 }

--- a/Assets/Code/Scripts/UI/LevelUI.cs
+++ b/Assets/Code/Scripts/UI/LevelUI.cs
@@ -72,6 +72,7 @@ public class LevelUI : MonoBehaviour
         }
         disableUIElement(confirm);
         bool fully = LevelManager.Instance.currentSubLevelID == -1 ? true : false;
+        Physics2D.gravity = new UnityEngine.Vector2(0f, -9.8f);
         StartCoroutine(CameraController.ZoomOut(fully));
         if (showMenu)
         {

--- a/Assets/Code/Scripts/UI/Menu.cs
+++ b/Assets/Code/Scripts/UI/Menu.cs
@@ -13,6 +13,7 @@ public class Menu : MonoBehaviour
     public void OnDailyButton()
     {
         Debug.Log("Load Daily Puzzle");
+        Physics2D.gravity = new UnityEngine.Vector2(0f, 9.8f);
         LevelManager.Instance.LoadLevel(0);
     }
 

--- a/Assets/Scenes/Levels/LevelOne/BreakRope.unity
+++ b/Assets/Scenes/Levels/LevelOne/BreakRope.unity
@@ -406,7 +406,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1979938359}
-  - {fileID: 1872345783}
   - {fileID: 1786227514}
   - {fileID: 1249142353}
   - {fileID: 368511278}
@@ -545,7 +544,7 @@ PrefabInstance:
     - target: {fileID: 3102746494672219261, guid: 7c367d30fe978434f989e041bd1b9096, type: 3}
       propertyPath: OnDragEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 1618786790}
+      objectReference: {fileID: 0}
     - target: {fileID: 3102746494672219261, guid: 7c367d30fe978434f989e041bd1b9096, type: 3}
       propertyPath: OnDragEndEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 0
@@ -691,9 +690,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1740465846098495637, guid: 7c367d30fe978434f989e041bd1b9096, type: 3}
       insertIndex: 2
       addedObject: {fileID: 1618786788}
-    - targetCorrespondingSourceObject: {fileID: 1740465846098495637, guid: 7c367d30fe978434f989e041bd1b9096, type: 3}
-      insertIndex: 3
-      addedObject: {fileID: 1618786790}
     - targetCorrespondingSourceObject: {fileID: 1740465846098495637, guid: 7c367d30fe978434f989e041bd1b9096, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1618786783}
@@ -11023,19 +11019,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tapParticles: {fileID: 6893540742718307453, guid: c4004c208c5cff34ebc0c2ab2f81a7bc, type: 3}
---- !u!114 &1618786790
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1618786779}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1c808aecee7e6f6499cd925df513a865, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  scale: 0
 --- !u!1 &1719057553 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9166951971181930119, guid: 93782211bdc23ce48b4154defad46e2f, type: 3}
@@ -11170,90 +11153,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6593986989481560103, guid: 06704280bc57b3f4897fc9c85f37e846, type: 3}
   m_PrefabInstance: {fileID: 1786227513}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1872345782
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1872345783}
-  - component: {fileID: 1872345784}
-  m_Layer: 0
-  m_Name: CutRope2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &1872345783
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1872345782}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.01, y: -3.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476380442}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1872345784
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1872345782}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 3667c3e6764114e49a0438346b3bcd2d, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.38085938, y: 1.9628906}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &1979938358
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Setting gravity in InjectSubLevel in Levelmanager effectively made it so gravity was constantly being set to the default value, since it wasn't protected by the same guard that the rest of the function was. Instead of levelmanager being responsible for resetting gravity, now gravity is reset in the following places:
1. Menu.cs in the OnDailyPuzzle function
2. LevelUI.cs in the OnZoomOutButton function
3. BoundaryWin.cs in the OnTriggerExit function